### PR TITLE
解决了 错误提示TypeError: Cannot read property 'height' of undefined

### DIFF
--- a/pages/classify/classify.vue
+++ b/pages/classify/classify.vue
@@ -45,7 +45,7 @@
 		onLoad: function () {
 			this.height = uni.getSystemInfoSync().windowHeight - this.tabBarHeight;
 		},
-		onReady() {
+		updated() {
 			this.getHeightList();
 		},
 		methods: {


### PR DESCRIPTION
createSelectorQuery（） 要求在VUE 生命周期 mounted 之后.